### PR TITLE
Fix memory leak.

### DIFF
--- a/EasyImagy/ImageCoreGraphics.swift
+++ b/EasyImagy/ImageCoreGraphics.swift
@@ -100,6 +100,8 @@ extension Image where Pixel: RGBAType { // Conversion
         
         let length = count * 4
         let buffer = UnsafeMutablePointer<UInt8>.alloc(length)
+        defer { buffer.dealloc(length) }
+        
         var pointer = buffer
         for pixel in zelf.pixels {
             let alphaInt = Int(pixel.alpha)
@@ -114,8 +116,6 @@ extension Image where Pixel: RGBAType { // Conversion
         }
         
         let provider: CGDataProvider = CGDataProviderCreateWithCFData(NSData(bytes: buffer, length: length))!
-        
-        buffer.dealloc(length)
         
         return CGImageCreate(width, height, 8, 32, width * 4, Image.colorSpace, Image.bitmapInfo, provider, nil, false, CGColorRenderingIntent.RenderingIntentDefault)!
     }

--- a/EasyImagy/ImageCoreGraphics.swift
+++ b/EasyImagy/ImageCoreGraphics.swift
@@ -115,6 +115,8 @@ extension Image where Pixel: RGBAType { // Conversion
         
         let provider: CGDataProvider = CGDataProviderCreateWithCFData(NSData(bytes: buffer, length: length))!
         
+        buffer.dealloc(length)
+        
         return CGImageCreate(width, height, 8, 32, width * 4, Image.colorSpace, Image.bitmapInfo, provider, nil, false, CGColorRenderingIntent.RenderingIntentDefault)!
     }
     


### PR DESCRIPTION
Deallocate pixel buffer after it is copied to `NSData(bytes:length:)`.
