### PR TITLE
Prevent realloc and copies by reserving capacity

### DIFF
--- a/Sources/EasyImagy/ImageProtocol.swift
+++ b/Sources/EasyImagy/ImageProtocol.swift
@@ -97,7 +97,7 @@ extension ImageProtocol {
 extension ImageProtocol {
     public func transposed() -> Image<Pixel> {
         var pixels = [Pixel]()
-        pixels.reserveCapacity(xRange.count * yRange.count)
+        pixels.reserveCapacity(count)
         
         for x in xRange {
             for y in yRange {
@@ -110,7 +110,7 @@ extension ImageProtocol {
     
     public func xReversed() -> Image<Pixel> {
         var pixels = [Pixel]()
-        pixels.reserveCapacity(xRange.count * yRange.count)
+        pixels.reserveCapacity(count)
         
         for y in yRange {
             for x in xRange.reversed() {
@@ -123,7 +123,7 @@ extension ImageProtocol {
     
     public func yReversed() -> Image<Pixel> {
         var pixels = [Pixel]()
-        pixels.reserveCapacity(xRange.count * yRange.count)
+        pixels.reserveCapacity(count)
         
         for y in yRange.reversed() {
             for x in xRange {
@@ -151,7 +151,7 @@ extension ImageProtocol {
             }
         case 1, -3:
             var pixels = [Pixel]()
-            pixels.reserveCapacity(xRange.count * yRange.count)
+            pixels.reserveCapacity(count)
             
             for y in xRange {
                 for x in yRange.reversed() {
@@ -162,7 +162,7 @@ extension ImageProtocol {
             return Image(width: height, height: width, pixels: pixels)
         case 2, -2:
             var pixels = [Pixel]()
-            pixels.reserveCapacity(xRange.count * yRange.count)
+            pixels.reserveCapacity(count)
             
             for y in yRange.reversed() {
                 for x in xRange.reversed() {
@@ -173,7 +173,7 @@ extension ImageProtocol {
             return Image(width: width, height: height, pixels: pixels)
         case 3, -1:
             var pixels = [Pixel]()
-            pixels.reserveCapacity(xRange.count * yRange.count)
+            pixels.reserveCapacity(count)
             
             for y in xRange.reversed() {
                 for x in yRange {

--- a/Sources/EasyImagy/ImageProtocol.swift
+++ b/Sources/EasyImagy/ImageProtocol.swift
@@ -72,6 +72,7 @@ extension ImageProtocol {
     
     public init(width: Int, height: Int, pixelAt: (_ x: Int, _ y: Int) throws -> Pixel) rethrows {
         var pixels = [Pixel]()
+        pixels.reserveCapacity(width * height)
         
         for y in 0..<height {
             for x in 0..<width {
@@ -96,6 +97,7 @@ extension ImageProtocol {
 extension ImageProtocol {
     public func transposed() -> Image<Pixel> {
         var pixels = [Pixel]()
+        pixels.reserveCapacity(xRange.count * yRange.count)
         
         for x in xRange {
             for y in yRange {
@@ -108,6 +110,7 @@ extension ImageProtocol {
     
     public func xReversed() -> Image<Pixel> {
         var pixels = [Pixel]()
+        pixels.reserveCapacity(xRange.count * yRange.count)
         
         for y in yRange {
             for x in xRange.reversed() {
@@ -120,6 +123,7 @@ extension ImageProtocol {
     
     public func yReversed() -> Image<Pixel> {
         var pixels = [Pixel]()
+        pixels.reserveCapacity(xRange.count * yRange.count)
         
         for y in yRange.reversed() {
             for x in xRange {
@@ -147,6 +151,7 @@ extension ImageProtocol {
             }
         case 1, -3:
             var pixels = [Pixel]()
+            pixels.reserveCapacity(xRange.count * yRange.count)
             
             for y in xRange {
                 for x in yRange.reversed() {
@@ -157,6 +162,7 @@ extension ImageProtocol {
             return Image(width: height, height: width, pixels: pixels)
         case 2, -2:
             var pixels = [Pixel]()
+            pixels.reserveCapacity(xRange.count * yRange.count)
             
             for y in yRange.reversed() {
                 for x in xRange.reversed() {
@@ -167,6 +173,7 @@ extension ImageProtocol {
             return Image(width: width, height: height, pixels: pixels)
         case 3, -1:
             var pixels = [Pixel]()
+            pixels.reserveCapacity(xRange.count * yRange.count)
             
             for y in xRange.reversed() {
                 for x in yRange {


### PR DESCRIPTION
When doing appends in a loop it is always better if you can pre-allocate the space if you know it.  In this case we do.