### PR TITLE
Develop 0.5.2

### DIFF
--- a/EasyImagy.xcodeproj/project.pbxproj
+++ b/EasyImagy.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		D6134AE41F85DA5C005592A2 /* RGBA.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6134A371F852A49005592A2 /* RGBA.swift */; };
 		D6134AE51F85DA5C005592A2 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6134A381F852A49005592A2 /* Util.swift */; };
 		D6134B0A1F85DC64005592A2 /* EasyImagy.h in Headers */ = {isa = PBXBuildFile; fileRef = D6134A2A1F852A49005592A2 /* EasyImagy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D62285B822115990006A6D9C /* AutoreleaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CE68902211564D00E3DD55 /* AutoreleaseTests.swift */; };
 		D62C6EBB1FC9DAD900E7DF02 /* RGBATyped.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60D48A61FA16BB90047F2D3 /* RGBATyped.swift */; };
 		D62C6EBC1FC9DADA00E7DF02 /* RGBATyped.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60D48A61FA16BB90047F2D3 /* RGBATyped.swift */; };
 		D62C6EBD1FC9DADB00E7DF02 /* RGBATyped.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60D48A61FA16BB90047F2D3 /* RGBATyped.swift */; };
@@ -156,6 +157,8 @@
 		D6C1C01E1FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C1C01D1FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift */; };
 		D6C1C01F1FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C1C01D1FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift */; };
 		D6C1C0201FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C1C01D1FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift */; };
+		D6CE68952211574800E3DD55 /* AutoreleaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CE68902211564D00E3DD55 /* AutoreleaseTests.swift */; };
+		D6CE68962211574900E3DD55 /* AutoreleaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CE68902211564D00E3DD55 /* AutoreleaseTests.swift */; };
 		D6D33DBB1FD97A8B00256FD0 /* ImageProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D33DBA1FD97A8B00256FD0 /* ImageProtocolTests.swift */; };
 		D6D33DBC1FD97A8B00256FD0 /* ImageProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D33DBA1FD97A8B00256FD0 /* ImageProtocolTests.swift */; };
 		D6D33DBD1FD97A8B00256FD0 /* ImageProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D33DBA1FD97A8B00256FD0 /* ImageProtocolTests.swift */; };
@@ -241,6 +244,7 @@
 		D6B4EE291FE4A1C200B6B7B0 /* Resizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resizing.swift; sourceTree = "<group>"; };
 		D6B8BF831FE57E22009C7C30 /* ResizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingTests.swift; sourceTree = "<group>"; };
 		D6C1C01D1FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HigherOrderFunctionsTests.swift; sourceTree = "<group>"; };
+		D6CE68902211564D00E3DD55 /* AutoreleaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoreleaseTests.swift; sourceTree = "<group>"; };
 		D6D33DBA1FD97A8B00256FD0 /* ImageProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProtocolTests.swift; sourceTree = "<group>"; };
 		D6FAC8691FD1938400509BCB /* ImageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -377,6 +381,7 @@
 			isa = PBXGroup;
 			children = (
 				D6B4EE201FE2699700B6B7B0 /* AnyImageTests.swift */,
+				D6CE68902211564D00E3DD55 /* AutoreleaseTests.swift */,
 				D63109161FCFF252009974D0 /* ConvolutionTests.swift */,
 				D6134A3B1F852A57005592A2 /* EasyImagyTests.swift */,
 				D62C6EE31FCE8F1800E7DF02 /* ExtrapolationTests.swift */,
@@ -724,6 +729,7 @@
 				D6B4EE131FE0DC4100B6B7B0 /* RotationTests.swift in Sources */,
 				D62C6EDB1FCE5F7D00E7DF02 /* InterpolationTests.swift in Sources */,
 				D6C1C01E1FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift in Sources */,
+				D62285B822115990006A6D9C /* AutoreleaseTests.swift in Sources */,
 				D6134A4B1F852A64005592A2 /* ImageSliceTests.swift in Sources */,
 				D6B4EE211FE2699700B6B7B0 /* AnyImageTests.swift in Sources */,
 				D6134A4A1F852A64005592A2 /* ImageCoreGraphicsTest.swift in Sources */,
@@ -780,6 +786,7 @@
 				D6B4EE141FE0DC4100B6B7B0 /* RotationTests.swift in Sources */,
 				D62C6EDC1FCE5F7E00E7DF02 /* InterpolationTests.swift in Sources */,
 				D6C1C01F1FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift in Sources */,
+				D6CE68962211574900E3DD55 /* AutoreleaseTests.swift in Sources */,
 				D6134A891F85CF6F005592A2 /* ImageSliceTests.swift in Sources */,
 				D6B4EE221FE2699700B6B7B0 /* AnyImageTests.swift in Sources */,
 				D6134A881F85CF6F005592A2 /* ImageCoreGraphicsTest.swift in Sources */,
@@ -836,6 +843,7 @@
 				D6B4EE151FE0DC4100B6B7B0 /* RotationTests.swift in Sources */,
 				D62C6EDD1FCE5F7E00E7DF02 /* InterpolationTests.swift in Sources */,
 				D6C1C0201FDFCB2500CAA6C4 /* HigherOrderFunctionsTests.swift in Sources */,
+				D6CE68952211574800E3DD55 /* AutoreleaseTests.swift in Sources */,
 				D6134AC81F85D2BF005592A2 /* ImageSliceTests.swift in Sources */,
 				D6B4EE231FE2699700B6B7B0 /* AnyImageTests.swift in Sources */,
 				D6134AC71F85D2BF005592A2 /* ImageCoreGraphicsTest.swift in Sources */,

--- a/Sources/EasyImagy/ImageAppKit.swift
+++ b/Sources/EasyImagy/ImageAppKit.swift
@@ -39,11 +39,14 @@ extension Image where Pixel == RGBA<UInt8> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -96,11 +99,14 @@ extension Image where Pixel == RGBA<UInt16> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -153,11 +159,14 @@ extension Image where Pixel == RGBA<UInt32> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -210,11 +219,14 @@ extension Image where Pixel == RGBA<Float> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -267,11 +279,14 @@ extension Image where Pixel == RGBA<Double> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -324,11 +339,14 @@ extension Image where Pixel == RGBA<Bool> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -381,11 +399,14 @@ extension Image where Pixel == PremultipliedRGBA<UInt8> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -438,11 +459,14 @@ extension Image where Pixel == PremultipliedRGBA<UInt16> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -495,11 +519,14 @@ extension Image where Pixel == PremultipliedRGBA<UInt32> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -552,11 +579,14 @@ extension Image where Pixel == PremultipliedRGBA<Float> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -609,11 +639,14 @@ extension Image where Pixel == PremultipliedRGBA<Double> {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -666,11 +699,14 @@ extension Image where Pixel == UInt8 {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -723,11 +759,14 @@ extension Image where Pixel == UInt16 {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -780,11 +819,14 @@ extension Image where Pixel == UInt32 {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -837,11 +879,14 @@ extension Image where Pixel == Float {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -894,11 +939,14 @@ extension Image where Pixel == Double {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 
@@ -951,11 +999,14 @@ extension Image where Pixel == Bool {
         let imageRep = NSBitmapImageRep(cgImage: cgImage)
         imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 

--- a/Sources/EasyImagy/ImageAppKit.swift
+++ b/Sources/EasyImagy/ImageAppKit.swift
@@ -36,11 +36,10 @@ extension Image where Pixel == RGBA<UInt8> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -96,11 +95,10 @@ extension Image where Pixel == RGBA<UInt16> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -156,11 +154,10 @@ extension Image where Pixel == RGBA<UInt32> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -216,11 +213,10 @@ extension Image where Pixel == RGBA<Float> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -276,11 +272,10 @@ extension Image where Pixel == RGBA<Double> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -336,11 +331,10 @@ extension Image where Pixel == RGBA<Bool> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -396,11 +390,10 @@ extension Image where Pixel == PremultipliedRGBA<UInt8> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -456,11 +449,10 @@ extension Image where Pixel == PremultipliedRGBA<UInt16> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -516,11 +508,10 @@ extension Image where Pixel == PremultipliedRGBA<UInt32> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -576,11 +567,10 @@ extension Image where Pixel == PremultipliedRGBA<Float> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -636,11 +626,10 @@ extension Image where Pixel == PremultipliedRGBA<Double> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -696,11 +685,10 @@ extension Image where Pixel == UInt8 {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -756,11 +744,10 @@ extension Image where Pixel == UInt16 {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -816,11 +803,10 @@ extension Image where Pixel == UInt32 {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -876,11 +862,10 @@ extension Image where Pixel == Float {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -936,11 +921,10 @@ extension Image where Pixel == Double {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])
@@ -996,11 +980,10 @@ extension Image where Pixel == Bool {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
-
-        // fix for memory deallocation problem (https://github.com/koher/EasyImagy/issues/38)
         return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+
             switch format {
             case .png:
                 return imageRep.representation(using: .png, properties: [:])

--- a/Sources/EasyImagy/ImageAppKit.swift.gyb
+++ b/Sources/EasyImagy/ImageAppKit.swift.gyb
@@ -45,14 +45,16 @@ extension Image where Pixel == ${pixel_type} {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
+        return autoreleasepool {
+            let imageRep = NSBitmapImageRep(cgImage: cgImage)
+            imageRep.size = CGSize(width: CGFloat(width), height: CGFloat(height))
 
-        switch format {
-        case .png:
-            return imageRep.representation(using: .png, properties: [:])
-        case .jpeg(let compressionQuality):
-            return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            switch format {
+            case .png:
+                return imageRep.representation(using: .png, properties: [:])
+            case .jpeg(let compressionQuality):
+                return imageRep.representation(using: .jpeg, properties: [.compressionFactor: NSNumber(value: compressionQuality)])
+            }
         }
     }
 

--- a/Sources/EasyImagy/ImageUIKit.swift
+++ b/Sources/EasyImagy/ImageUIKit.swift
@@ -68,11 +68,13 @@ extension Image where Pixel == RGBA<UInt8> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -138,11 +140,13 @@ extension Image where Pixel == RGBA<UInt16> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -208,11 +212,13 @@ extension Image where Pixel == RGBA<UInt32> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -278,11 +284,13 @@ extension Image where Pixel == RGBA<Float> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -348,11 +356,13 @@ extension Image where Pixel == RGBA<Double> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -418,11 +428,13 @@ extension Image where Pixel == RGBA<Bool> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -488,11 +500,13 @@ extension Image where Pixel == PremultipliedRGBA<UInt8> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -558,11 +572,13 @@ extension Image where Pixel == PremultipliedRGBA<UInt16> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -628,11 +644,13 @@ extension Image where Pixel == PremultipliedRGBA<UInt32> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -698,11 +716,13 @@ extension Image where Pixel == PremultipliedRGBA<Float> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -768,11 +788,13 @@ extension Image where Pixel == PremultipliedRGBA<Double> {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -838,11 +860,13 @@ extension Image where Pixel == UInt8 {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -908,11 +932,13 @@ extension Image where Pixel == UInt16 {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -978,11 +1004,13 @@ extension Image where Pixel == UInt32 {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -1048,11 +1076,13 @@ extension Image where Pixel == Float {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -1118,11 +1148,13 @@ extension Image where Pixel == Double {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 
@@ -1188,11 +1220,13 @@ extension Image where Pixel == Bool {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 

--- a/Sources/EasyImagy/ImageUIKit.swift.gyb
+++ b/Sources/EasyImagy/ImageUIKit.swift.gyb
@@ -77,11 +77,13 @@ extension Image where Pixel == ${pixel_type} {
     public func data(using format: Image.Format) -> Data? {
         guard width > 0 && height > 0 else { return nil }
 
-        switch format {
-        case .png:
-            return UIImagePNGRepresentation(uiImage)
-        case .jpeg(let compressionQuality):
-            return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+        return autoreleasepool {
+            switch format {
+            case .png:
+                return UIImagePNGRepresentation(uiImage)
+            case .jpeg(let compressionQuality):
+                return UIImageJPEGRepresentation(uiImage, CGFloat(compressionQuality))
+            }
         }
     }
 

--- a/Tests/EasyImagyTests/AutoreleaseTests.swift
+++ b/Tests/EasyImagyTests/AutoreleaseTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import EasyImagy
+
+class AutoreleaseTests: XCTestCase {
+    func testPNGData() {
+        let image = Image<UInt8>(width: 100, height: 100, pixel: 42)
+        
+        for _ in 0..<100 {
+            let _ = image.data(using: .png)
+        }
+        
+        XCTAssertTrue(true) // Break here and check if `CGImage` instances are released.
+    }
+    
+    func testJPEGData() {
+        let image = Image<UInt8>(width: 100, height: 100, pixel: 42)
+        
+        for _ in 0..<100 {
+            let _ = image.data(using: .jpeg(compressionQuality: 0.8))
+        }
+        
+        XCTAssertTrue(true) // Break here and check if `CGImage` instances are released.
+    }
+}

--- a/Tests/EasyImagyTests/AutoreleaseTests.swift
+++ b/Tests/EasyImagyTests/AutoreleaseTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 import EasyImagy
 
+#if canImport(AppKit) || canImport(UIKit)
+
 class AutoreleaseTests: XCTestCase {
     func testPNGData() {
         let image = Image<UInt8>(width: 100, height: 100, pixel: 42)
@@ -22,3 +24,5 @@ class AutoreleaseTests: XCTestCase {
         XCTAssertTrue(true) // Break here and check if `CGImage` instances are released.
     }
 }
+
+#endif


### PR DESCRIPTION
- Fixes a kind of memory leaks: `CGImage` instances created in the `data(using:)` method internally had been autoreleased by Obj-C frameworks. It may have caused problems when `data(using:)` was used heavily in a loop without manual `autoreleasepool`.